### PR TITLE
fix: parse the summary of search results

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "antd": "^5.3.3",
     "axios": "^1.3.4",
     "dayjs": "^1.11.7",
+    "marked": "^14.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.10.0"

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -5,6 +5,7 @@ import {
 } from '@ant-design/icons';
 import { Card, Tag } from 'antd';
 import dayjs from 'dayjs';
+import { marked } from 'marked';
 import { useLocation } from 'react-router-dom';
 
 import type { Post } from '../api/types';
@@ -15,6 +16,12 @@ const PostCard = ({ post }: { post: Post }) => {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const fullTextFlag = params.get('f') === 'true';
+  const htmlSummary = marked.parse(post.content.replace(/\n{3,}/g, '\n\n'));
+  const summary = htmlSummary
+    .replace(/<[^>]*>/g, '')
+    .replace(/:::|{.*}|{.*/g, '');
+  // TODO: 全文输出解析字体问题
+  post.content = fullTextFlag ? post.content : summary;
   return (
     <Card
       title={<div dangerouslySetInnerHTML={{ __html: post.title }} />}
@@ -48,9 +55,7 @@ const PostCard = ({ post }: { post: Post }) => {
         <div
           className="break-words"
           dangerouslySetInnerHTML={{
-            __html: fullTextFlag
-              ? post.content.replace(/\n{3,}/g, '\n\n').replace(/\n/g, '<br>')
-              : post.content,
+            __html: post.content,
           }}
         ></div>
         {post.tags && (


### PR DESCRIPTION
This pull request introduced the integration of the Marked library to enhance the analysis and presentation of the search results. The current implementation depends on basic string operations, and it cannot handle complex HTML and Markdown structures.

I'm trying to parse the abstract and improve the overall readability of the search results. It works, but it needs a little test😊